### PR TITLE
Add "internal-link" class to links on archive page

### DIFF
--- a/_pages/archive.md
+++ b/_pages/archive.md
@@ -6,7 +6,7 @@ permalink: /archive
 <ul>
   {% for post in site.notes %}
     <li>
-      <a href="{{ post.url }}">{{ post.title }}</a>
+      <a class="internal-link" href="{{ post.url }}">{{ post.title }}</a>
       {{ post.date | date_to_long_string }}
     </li>
   {% endfor %}


### PR DESCRIPTION
This pull request removes the "external link" arrow and colors the links' backgrounds on the Archive page.

## Before

![2021-02-20-191358_338x107_scrot](https://user-images.githubusercontent.com/8457808/108611764-b499ae00-73d9-11eb-82ec-689f406c33c4.png)

## After

![2021-02-20-191330_346x116_scrot](https://user-images.githubusercontent.com/8457808/108611762-a9468280-73d9-11eb-91ac-156be8993244.png)
